### PR TITLE
Added support for HTML mail and templates

### DIFF
--- a/mail.py
+++ b/mail.py
@@ -81,6 +81,6 @@ def send(mail_msg, mail_server=MailServer()):
     if mail_server.require_starttls:
         server.starttls()
     server.login(mail_server.username, mail_server.password)
-    server.sendmail(mail_msg.from_email, mail_msg.to_emails, mail_msg.get_message().as_string())
+    server.sendmail(mail_msg.from_email, (mail_msg.to_emails + mail_msg.cc_emails), mail_msg.get_message().as_string())
     server.close()
 

--- a/mail.py
+++ b/mail.py
@@ -68,7 +68,7 @@ class MailMessage(object):
 class MailServer(object):
     msg = None
 
-    def __init__(self, server_name='smtp.gmail.com', username='<username>', password='<password>', port=0, require_starttls=True):
+    def __init__(self, server_name='smtp.gmail.com', username='<username>', password='<password>', port=587, require_starttls=True):
         self.server_name = server_name
         self.username = username
         self.password = password
@@ -77,10 +77,11 @@ class MailServer(object):
 
 
 def send(mail_msg, mail_server=MailServer()):
-    server = smtplib.SMTP(mail_server.server_name, 587)
+    server = smtplib.SMTP(mail_server.server_name, mail_server.port)
     if mail_server.require_starttls:
         server.starttls()
-    server.login(mail_server.username, mail_server.password)
+    if mail_server.username:
+        server.login(mail_server.username, mail_server.password)
     server.sendmail(mail_msg.from_email, (mail_msg.to_emails + mail_msg.cc_emails), mail_msg.get_message().as_string())
     server.close()
 

--- a/mail.py
+++ b/mail.py
@@ -3,6 +3,7 @@ __author__ = 'Ludmal.DESILVA'
 import os, email, smtplib
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
+from email.mime.application import MIMEApplication
 
 path = os.path.dirname(__file__)
 #modify this to change the Template Directory
@@ -27,13 +28,17 @@ class EmailTemplate():
 class MailMessage(object):
     html = False
 
-    def __init__(self, from_email='', to_emails=[], cc_emails=[], subject='', body='', template=None):
+    def __init__(self, from_email='', to_emails=[], cc_emails=[], subject='', body='', template=None, attachments=[]):
         self.from_email = from_email
         self.to_emails = to_emails
         self.cc_emails = cc_emails
         self.subject = subject
         self.template = template
         self.body = body
+        self.file_attachments = attachments
+
+    def attach_file(self, path):
+        self.file_attachments.append(path)
 
     def get_message(self):
         if isinstance(self.to_emails, str):
@@ -62,6 +67,13 @@ class MailMessage(object):
                 msg.attach(MIMEText(self.template.render(),'plain'))
         else:
                 msg.attach(MIMEText(self.body, 'plain'))
+
+        for attachment in self.file_attachments:
+            with open(attachment, "rb") as f:
+                filename = os.path.basename(attachment)
+                part = MIMEApplication(f.read(), Name=filename)
+                part['Content-Disposition'] = 'attachment; filename="' + str(filename) + '"'
+                msg.attach(part)
         return msg
 
 


### PR DESCRIPTION
We needed a python html mail template tool. This one fit the bill but wasn't complete.

Changes:
Will also send a plaintext copy if 'body' is specified and template is an 'html' template. 
If the template is not an 'html' template, the template will be sent as plaintext. 
If no template is specified, body will be sent.
Removed 'template' from send, and added it to MailMessage
Changed generic Exception to ValueError
